### PR TITLE
feat: add configurable factory paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,31 @@ A VSCode extension that enables quick navigation from Rails test files to Factor
 - Supports both `spec/factories` and `test/factories` directories
 - Caches factory definitions for faster navigation
 - Automatically updates cache when factory files are modified
+- Configurable factory file search paths
 
 ## Usage
 
 1. Open a Rails test file containing FactoryBot factory calls
 2. Hover over a factory call (e.g., `create(:user)`)
 3. Hold Cmd (Mac) or Ctrl (Windows) and click the link to jump to the factory definition
+
+## Configuration
+
+You can configure the paths where the extension searches for factory files by adding the following to your VSCode settings (settings.json):
+
+```json
+{
+  "rails-factorybot-jump.factoryPaths": [
+    "spec/factories/**/*.rb",
+    "test/factories/**/*.rb",
+    "custom/path/to/factories/**/*.rb"
+  ]
+}
+```
+
+- The default path is `["spec/factories/**/*.rb"]`
+- You can specify multiple paths using glob patterns
+- Changes to the configuration will automatically update the factory search paths
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,22 @@
         "scheme": "file",
         "language": "ruby"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Rails FactoryBot Jump",
+      "properties": {
+        "rails-factorybot-jump.factoryPaths": {
+          "type": "array",
+          "default": [
+            "spec/factories/**/*.rb"
+          ],
+          "description": "Paths to search for factory files. Supports glob patterns.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 
 export class FactoryLinkProvider implements vscode.DocumentLinkProvider {
   private factoryCache: Map<string, { uri: vscode.Uri; lineNumber: number }> =
@@ -23,13 +24,13 @@ export class FactoryLinkProvider implements vscode.DocumentLinkProvider {
 
     // Get factory paths from configuration
     const config = vscode.workspace.getConfiguration("rails-factorybot-jump");
-    const factoryPaths = config.get<string[]>("factoryPaths", [
-      "spec/factories/**/*.rb",
-    ]);
+    const defaultPath = path.join("spec", "factories", "**", "*.rb");
+    const factoryPaths = config.get<string[]>("factoryPaths", [defaultPath]);
 
     // Factory file search patterns
     const patterns = factoryPaths.map(
-      (path) => new vscode.RelativePattern(workspaceFolders[0], path)
+      (pathPattern) =>
+        new vscode.RelativePattern(workspaceFolders[0], pathPattern)
     );
 
     // Search for files matching all patterns

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,13 +24,16 @@ export class FactoryLinkProvider implements vscode.DocumentLinkProvider {
 
     // Get factory paths from configuration
     const config = vscode.workspace.getConfiguration("rails-factorybot-jump");
-    const defaultPath = path.join("spec", "factories", "**", "*.rb");
+    const defaultPath = path.posix.join("spec", "factories", "**", "*.rb");
     const factoryPaths = config.get<string[]>("factoryPaths", [defaultPath]);
 
     // Factory file search patterns
     const patterns = factoryPaths.map(
       (pathPattern) =>
-        new vscode.RelativePattern(workspaceFolders[0], pathPattern)
+        new vscode.RelativePattern(
+          workspaceFolders[0],
+          pathPattern.replace(/\\/g, "/")
+        )
     );
 
     // Search for files matching all patterns

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,11 +21,16 @@ export class FactoryLinkProvider implements vscode.DocumentLinkProvider {
       return;
     }
 
+    // Get factory paths from configuration
+    const config = vscode.workspace.getConfiguration("rails-factorybot-jump");
+    const factoryPaths = config.get<string[]>("factoryPaths", [
+      "spec/factories/**/*.rb",
+    ]);
+
     // Factory file search patterns
-    const patterns = [
-      new vscode.RelativePattern(workspaceFolders[0], "spec/factories/**/*.rb"),
-      new vscode.RelativePattern(workspaceFolders[0], "test/factories/**/*.rb"),
-    ];
+    const patterns = factoryPaths.map(
+      (path) => new vscode.RelativePattern(workspaceFolders[0], path)
+    );
 
     // Search for files matching all patterns
     for (const pattern of patterns) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -136,7 +136,12 @@ suite("Extension Test Suite", () => {
     `;
 
     const factoryFile = vscode.Uri.file(
-      path.join(testWorkspacePath, "spec", "factories", "test_factories.rb")
+      path.posix.join(
+        testWorkspacePath,
+        "spec",
+        "factories",
+        "test_factories.rb"
+      )
     );
 
     await vscode.workspace.fs.writeFile(
@@ -159,7 +164,12 @@ suite("Extension Test Suite", () => {
 
   test("FactoryLinkProvider should handle file system changes", async () => {
     const factoryFile = vscode.Uri.file(
-      path.join(testWorkspacePath, "spec", "factories", "test_factories.rb")
+      path.posix.join(
+        testWorkspacePath,
+        "spec",
+        "factories",
+        "test_factories.rb"
+      )
     );
 
     // Create initial factory file
@@ -213,7 +223,12 @@ suite("Extension Test Suite", () => {
 
     const factoryContent = "factory :user do\n  name { 'John' }\nend";
     const factoryFile = vscode.Uri.file(
-      path.join(testWorkspacePath, "spec", "factories", "test_factories.rb")
+      path.posix.join(
+        testWorkspacePath,
+        "spec",
+        "factories",
+        "test_factories.rb"
+      )
     );
 
     await vscode.workspace.fs.writeFile(
@@ -246,7 +261,12 @@ suite("Extension Test Suite", () => {
 
     const factoryContent = "factory :user do\n  name { 'John' }\nend";
     const factoryFile = vscode.Uri.file(
-      path.join(testWorkspacePath, "custom", "factories", "test_factories.rb")
+      path.posix.join(
+        testWorkspacePath,
+        "custom",
+        "factories",
+        "test_factories.rb"
+      )
     );
 
     await vscode.workspace.fs.writeFile(
@@ -284,10 +304,20 @@ suite("Extension Test Suite", () => {
     const factoryContent2 = "factory :post do\n  title { 'Test' }\nend";
 
     const factoryFile1 = vscode.Uri.file(
-      path.join(testWorkspacePath, "spec", "factories", "test_factories.rb")
+      path.posix.join(
+        testWorkspacePath,
+        "spec",
+        "factories",
+        "test_factories.rb"
+      )
     );
     const factoryFile2 = vscode.Uri.file(
-      path.join(testWorkspacePath, "custom", "factories", "test_factories.rb")
+      path.posix.join(
+        testWorkspacePath,
+        "custom",
+        "factories",
+        "test_factories.rb"
+      )
     );
 
     await vscode.workspace.fs.writeFile(

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -203,7 +203,7 @@ suite("Extension Test Suite", () => {
       value: () => ({
         get: (key: string) => {
           if (key === "factoryPaths") {
-            return [path.join("spec", "factories", "**", "*.rb")];
+            return [path.posix.join("spec", "factories", "**", "*.rb")];
           }
           return undefined;
         },
@@ -236,7 +236,7 @@ suite("Extension Test Suite", () => {
       value: () => ({
         get: (key: string) => {
           if (key === "factoryPaths") {
-            return [path.join("custom", "factories", "**", "*.rb")];
+            return [path.posix.join("custom", "factories", "**", "*.rb")];
           }
           return undefined;
         },
@@ -270,8 +270,8 @@ suite("Extension Test Suite", () => {
         get: (key: string) => {
           if (key === "factoryPaths") {
             return [
-              path.join("spec", "factories", "**", "*.rb"),
-              path.join("custom", "factories", "**", "*.rb"),
+              path.posix.join("spec", "factories", "**", "*.rb"),
+              path.posix.join("custom", "factories", "**", "*.rb"),
             ];
           }
           return undefined;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -136,12 +136,7 @@ suite("Extension Test Suite", () => {
     `;
 
     const factoryFile = vscode.Uri.file(
-      path.posix.join(
-        testWorkspacePath,
-        "spec",
-        "factories",
-        "test_factories.rb"
-      )
+      path.join(testWorkspacePath, "spec", "factories", "test_factories.rb")
     );
 
     await vscode.workspace.fs.writeFile(
@@ -164,12 +159,7 @@ suite("Extension Test Suite", () => {
 
   test("FactoryLinkProvider should handle file system changes", async () => {
     const factoryFile = vscode.Uri.file(
-      path.posix.join(
-        testWorkspacePath,
-        "spec",
-        "factories",
-        "test_factories.rb"
-      )
+      path.join(testWorkspacePath, "spec", "factories", "test_factories.rb")
     );
 
     // Create initial factory file
@@ -223,12 +213,7 @@ suite("Extension Test Suite", () => {
 
     const factoryContent = "factory :user do\n  name { 'John' }\nend";
     const factoryFile = vscode.Uri.file(
-      path.posix.join(
-        testWorkspacePath,
-        "spec",
-        "factories",
-        "test_factories.rb"
-      )
+      path.join(testWorkspacePath, "spec", "factories", "test_factories.rb")
     );
 
     await vscode.workspace.fs.writeFile(
@@ -261,12 +246,7 @@ suite("Extension Test Suite", () => {
 
     const factoryContent = "factory :user do\n  name { 'John' }\nend";
     const factoryFile = vscode.Uri.file(
-      path.posix.join(
-        testWorkspacePath,
-        "custom",
-        "factories",
-        "test_factories.rb"
-      )
+      path.join(testWorkspacePath, "custom", "factories", "test_factories.rb")
     );
 
     await vscode.workspace.fs.writeFile(
@@ -304,20 +284,10 @@ suite("Extension Test Suite", () => {
     const factoryContent2 = "factory :post do\n  title { 'Test' }\nend";
 
     const factoryFile1 = vscode.Uri.file(
-      path.posix.join(
-        testWorkspacePath,
-        "spec",
-        "factories",
-        "test_factories.rb"
-      )
+      path.join(testWorkspacePath, "spec", "factories", "test_factories.rb")
     );
     const factoryFile2 = vscode.Uri.file(
-      path.posix.join(
-        testWorkspacePath,
-        "custom",
-        "factories",
-        "test_factories.rb"
-      )
+      path.join(testWorkspacePath, "custom", "factories", "test_factories.rb")
     );
 
     await vscode.workspace.fs.writeFile(

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -203,7 +203,7 @@ suite("Extension Test Suite", () => {
       value: () => ({
         get: (key: string) => {
           if (key === "factoryPaths") {
-            return ["spec/factories/**/*.rb"];
+            return [path.join("spec", "factories", "**", "*.rb")];
           }
           return undefined;
         },
@@ -236,7 +236,7 @@ suite("Extension Test Suite", () => {
       value: () => ({
         get: (key: string) => {
           if (key === "factoryPaths") {
-            return ["custom/factories/**/*.rb"];
+            return [path.join("custom", "factories", "**", "*.rb")];
           }
           return undefined;
         },
@@ -269,7 +269,10 @@ suite("Extension Test Suite", () => {
       value: () => ({
         get: (key: string) => {
           if (key === "factoryPaths") {
-            return ["spec/factories/**/*.rb", "custom/factories/**/*.rb"];
+            return [
+              path.join("spec", "factories", "**", "*.rb"),
+              path.join("custom", "factories", "**", "*.rb"),
+            ];
           }
           return undefined;
         },


### PR DESCRIPTION
## Description

This PR adds a new configuration feature to allow users to customize the paths where factory files are searched.

### Changes

1. Added a new configuration option `rails-factorybot-jump.factoryPaths` in `package.json`
   - Default value: `["spec/factories/**/*.rb"]`
   - Supports multiple paths using glob patterns

2. Updated `extension.ts` to use the configured paths
   - Reads paths from VSCode settings
   - Falls back to default path if no configuration is provided

3. Added comprehensive test cases in `extension.test.ts`
   - Tests default path behavior
   - Tests custom path configuration
   - Tests multiple paths configuration

4. Updated `README.md` with configuration documentation
   - Added configuration section
   - Provided usage examples
   - Explained default behavior

### Testing

- [x] Default path works correctly
- [x] Custom path works correctly
- [x] Multiple paths work correctly
- [x] No configuration falls back to default
- [x] Configuration changes are applied immediately
